### PR TITLE
Fix a problem with expect_any_instance_of and rspec3

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -80,6 +80,12 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :fetch_message_max_bytes, :validate => :number, :default => 1048576
 
   public
+  def initialize(params={}, kafka_group_class=Kafka::Group)
+    super(params)
+    @kafka_group_class = kafka_group_class
+  end
+
+  public
   def register
     require 'jruby-kafka'
     options = {
@@ -98,7 +104,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       options[:reset_beginning] = 'from-beginning'
     end # if :reset_beginning
     @kafka_client_queue = SizedQueue.new(@queue_size)
-    @consumer_group = Kafka::Group.new(options)
+    @consumer_group = @kafka_group_class.new(options)
     @logger.info('Registering kafka', :group_id => @group_id, :topic_id => @topic_id, :zk_connect => @zk_connect)
   end # def register
 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -80,12 +80,6 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :fetch_message_max_bytes, :validate => :number, :default => 1048576
 
   public
-  def initialize(params={}, kafka_group_class=Kafka::Group)
-    super(params)
-    @kafka_group_class = kafka_group_class
-  end
-
-  public
   def register
     require 'jruby-kafka'
     options = {
@@ -104,7 +98,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       options[:reset_beginning] = 'from-beginning'
     end # if :reset_beginning
     @kafka_client_queue = SizedQueue.new(@queue_size)
-    @consumer_group = @kafka_group_class.new(options)
+    @consumer_group = create_consumer_group(options)
     @logger.info('Registering kafka', :group_id => @group_id, :topic_id => @topic_id, :zk_connect => @zk_connect)
   end # def register
 
@@ -139,6 +133,11 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
     end
     finished
   end # def run
+
+  private
+  def create_consumer_group(options)
+    Kafka::Group.new(options)
+  end
 
   private
   def queue_event(msg, output_queue)

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-kafka'
-  s.version         = '0.1.5'
+  s.version         = '0.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/kafka_spec.rb
+++ b/spec/inputs/kafka_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/kafka"
+require 'jruby-kafka'
 
 class LogStash::Inputs::TestKafka < LogStash::Inputs::Kafka
   milestone 1
@@ -12,6 +13,12 @@ class LogStash::Inputs::TestKafka < LogStash::Inputs::Kafka
   end
 end
 
+
+class TestKafkaGroup < Kafka::Group
+  def run(a_num_threads, a_queue)
+    a_queue << 'Kafka message'
+  end
+end
 
 describe 'inputs/kafka' do
   let (:kafka_config) {{'topic_id' => 'test'}}
@@ -31,12 +38,8 @@ describe 'inputs/kafka' do
   end
 
   it 'should retrieve event from kafka' do
-    kafka = LogStash::Inputs::TestKafka.new(kafka_config)
+    kafka = LogStash::Inputs::TestKafka.new(kafka_config, TestKafkaGroup)
     kafka.register
-
-    expect_any_instance_of(Kafka::Group).to receive(:run) do |a_num_threads, a_queue|
-      a_queue << 'Kafka message'
-    end
 
     logstash_queue = Queue.new
     kafka.run logstash_queue
@@ -47,12 +50,8 @@ describe 'inputs/kafka' do
   end
 
   it 'should retrieve a decorated event from kafka' do
-    kafka = LogStash::Inputs::TestKafka.new(decorated_kafka_config)
+    kafka = LogStash::Inputs::TestKafka.new(decorated_kafka_config, TestKafkaGroup)
     kafka.register
-
-    expect_any_instance_of(Kafka::Group).to receive(:run) do |a_num_threads, a_queue|
-      a_queue << 'Kafka message'
-    end
 
     logstash_queue = Queue.new
     kafka.run logstash_queue

--- a/spec/inputs/kafka_spec.rb
+++ b/spec/inputs/kafka_spec.rb
@@ -38,7 +38,10 @@ describe 'inputs/kafka' do
   end
 
   it 'should retrieve event from kafka' do
-    kafka = LogStash::Inputs::TestKafka.new(kafka_config, TestKafkaGroup)
+    kafka = LogStash::Inputs::TestKafka.new(kafka_config)
+    expect(kafka).to receive(:create_consumer_group) do |options|
+      TestKafkaGroup.new(options)
+    end
     kafka.register
 
     logstash_queue = Queue.new
@@ -50,7 +53,10 @@ describe 'inputs/kafka' do
   end
 
   it 'should retrieve a decorated event from kafka' do
-    kafka = LogStash::Inputs::TestKafka.new(decorated_kafka_config, TestKafkaGroup)
+    kafka = LogStash::Inputs::TestKafka.new(decorated_kafka_config)
+    expect(kafka).to receive(:create_consumer_group) do |options|
+      TestKafkaGroup.new(options)
+    end
     kafka.register
 
     logstash_queue = Queue.new


### PR DESCRIPTION
Fix a problem using RSpec3 where the usage of expect_any_instance_of like this
```
 expect_any_instance_of(Class).to receive(:method) do |a, b|
 end
```
as causing an infinite loop, so the test where basically hanging.

Used this issue to inject the problematic class as a dependency, even if in some cases the usage of this kind of expectations can be accepted, I understand is something we should avoid as might be problematic and sometimes it show design smells.

Link: https://relishapp.com/rspec/rspec-mocks/docs/working-with-legacy-code/any-instance