### PR TITLE
Fix jar-dependencies issue with version upgrade

### DIFF
--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-kafka'
-  s.version         = '0.1.8'
+  s.version         = '0.1.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -28,7 +28,17 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_runtime_dependency 'logstash-codec-plain'
 
-  s.add_runtime_dependency 'jar-dependencies', ['~> 0.1.0']
+  # Currently there is a blocking issue with the latest (3.1.1.0.9) version of 
+  # `ruby-maven` # and installing jars dependencies. If you are declaring a gem 
+  # in a gemfile # using the :github option it will make the bundle install crash,
+  # before upgrading this gem you need to test the version with any plugins
+  # that require jars.
+  #
+  # Ticket: https://github.com/elasticsearch/logstash/issues/2595
+  s.add_runtime_dependency 'jar-dependencies', '0.1.7'
+  s.add_runtime_dependency 'ruby-maven', '3.1.1.0.8'
+  s.add_runtime_dependency "maven-tools", '1.0.7'
+
   s.add_runtime_dependency 'jruby-kafka', ['>=0.2.1']
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
This PR fix, by bounding the jar-dependencies and ruby-maven to a given version.

Fixes #21 