### PR TITLE
add decoder options

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -80,6 +80,11 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # maximum message size the server allows or else it is possible for the producer to send
   # messages larger than the consumer can fetch.
   config :fetch_message_max_bytes, :validate => :number, :default => 1048576
+  # The serializer class for messages. The default decoder takes a byte[] and returns the same byte[]
+  config :decoder_class, :validate => :string, :default => 'kafka.serializer.DefaultDecoder'
+  # The serializer class for keys (defaults to the same default as for messages)
+  config :key_decoder_class, :validate => :string, :default => 'kafka.serializer.DefaultDecoder'
+
 
   public
   def register
@@ -97,7 +102,9 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         :consumer_id => @consumer_id,
         :fetch_message_max_bytes => @fetch_message_max_bytes,
         :allow_topics => @white_list,
-        :filter_topics => @black_list
+        :filter_topics => @black_list,
+        :value_decoder_class => @decoder_class,
+        :key_decoder_class => @key_decoder_class
     }
     if @reset_beginning
       options[:reset_beginning] = 'from-beginning'

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ruby-maven', '3.1.1.0.8'
   s.add_runtime_dependency "maven-tools", '1.0.7'
 
-  s.add_runtime_dependency 'jruby-kafka', ['>= 1.1.0', '< 2.0.0']
+  s.add_runtime_dependency 'jruby-kafka', ['>= 1.2.0', '< 2.0.0']
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
This PR will allow individuals to apply their own decoder for Kafka messages

_example:_
```bash
# let logstash runtime to load your custom library so you can use it!
$ export CLASSPATH=/path/to/lib.jar
```
```ruby
# logstash config
input {
  kafka {
    topic_id => "my_custom_topic"
    decoder_class => "org.logstash.dots.DotsDecoder"
  }
}
```
