### PR TITLE
Expose ZK commit interval setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 1.0.1
+ - Expose ZK commit interval setting (auto_commit_interval)

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -90,6 +90,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :decoder_class, :validate => :string, :default => 'kafka.serializer.DefaultDecoder'
   # The serializer class for keys (defaults to the same default as for messages)
   config :key_decoder_class, :validate => :string, :default => 'kafka.serializer.DefaultDecoder'
+  # The frequency in ms that the consumer offsets are committed to zookeeper.
+  config :auto_commit_interval, :validate => :string, :default => '1000'
 
 
   public
@@ -110,7 +112,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         :allow_topics => @white_list,
         :filter_topics => @black_list,
         :value_decoder_class => @decoder_class,
-        :key_decoder_class => @key_decoder_class
+        :key_decoder_class => @key_decoder_class,
+        :auto_commit_interval => @auto_commit_interval
     }
     if @reset_beginning
       options[:reset_beginning] = 'from-beginning'

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-kafka'
-  s.version         = '1.0.0'
+  s.version         = '1.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
So we can delay the checkpointing. The default is 1s which maybe too low in some usecases. Kafka consumer defaults to 1min. https://kafka.apache.org/08/configuration.html