### PR TITLE
remove unnecessary queue size check

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -136,10 +136,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       @consumer_group.run(@consumer_threads,@kafka_client_queue)
 
       while !stop?
-        if !@kafka_client_queue.empty?
-          event = @kafka_client_queue.pop
-          queue_event(event, logstash_queue)
-        end
+        event = @kafka_client_queue.pop
+        queue_event(event, logstash_queue)
       end
 
       until @kafka_client_queue.empty?


### PR DESCRIPTION
When no new events are being processed, the run loop will cycle forever and eat CPU.

This removes the unnecessary check for the queue's size and allows the `#pop` to block until 
further messages are to be processed.