### PR TITLE
Expose auto_commit_interval_ms to control offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.0.4
  - Fix safe shutdown while plugin waits on Kafka for new events
+ - Expose auto_commit_interval_ms to control offset commit frequency
 
 ## 2.0.3
  - Fix infinite loop when no new messages are found in Kafka

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -50,6 +50,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # have an established offset or offset is invalid, start with the earliest message present in the
   # log (`smallest`) or after the last message in the log (`largest`).
   config :auto_offset_reset, :validate => %w( largest smallest ), :default => 'largest'
+  # The frequency in ms that the consumer offsets are committed to zookeeper.
+  config :auto_commit_interval_ms, :validate => :number, :default => 60 * 1000
   # Number of threads to read from the partitions. Ideally you should have as many threads as the
   # number of partitions for a perfect balance. More threads than partitions means that some
   # threads will be idle. Less threads means a single thread could be consuming from more than
@@ -103,6 +105,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         :group_id => @group_id,
         :topic_id => @topic_id,
         :auto_offset_reset => @auto_offset_reset,
+        :auto_commit_interval_ms => @auto_commit_interval_ms,
         :rebalance_max_retries => @rebalance_max_retries,
         :rebalance_backoff_ms => @rebalance_backoff_ms,
         :consumer_timeout_ms => @consumer_timeout_ms,

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -51,7 +51,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   # log (`smallest`) or after the last message in the log (`largest`).
   config :auto_offset_reset, :validate => %w( largest smallest ), :default => 'largest'
   # The frequency in ms that the consumer offsets are committed to zookeeper.
-  config :auto_commit_interval_ms, :validate => :number, :default => 60 * 1000
+  config :auto_commit_interval_ms, :validate => :number, :default => 1000
   # Number of threads to read from the partitions. Ideally you should have as many threads as the
   # number of partitions for a perfect balance. More threads than partitions means that some
   # threads will be idle. Less threads means a single thread could be consuming from more than
@@ -105,7 +105,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         :group_id => @group_id,
         :topic_id => @topic_id,
         :auto_offset_reset => @auto_offset_reset,
-        :auto_commit_interval_ms => @auto_commit_interval_ms,
+        :auto_commit_interval => @auto_commit_interval_ms,
         :rebalance_max_retries => @rebalance_max_retries,
         :rebalance_backoff_ms => @rebalance_backoff_ms,
         :consumer_timeout_ms => @consumer_timeout_ms,

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
 
-  s.add_runtime_dependency 'jruby-kafka', ['>= 1.2.0', '< 2.0.0']
+  s.add_runtime_dependency 'jruby-kafka', '1.5.0'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Expose `auto_commit_interval_ms` to control offset commit frequency
Pin jruby-kafka to 1.5.0