### PR TITLE
use jruby-kafka v1.6.0 for lz4 support (Close #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+ - Update to jruby-kafka 1.5 which includes Kafka 0.8.2.2 enabling LZO decompression.
+ 
 ## 2.0.4
  - Fix safe shutdown while plugin waits on Kafka for new events
  - Expose auto_commit_interval_ms to control offset commit frequency

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-kafka'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
 
-  s.add_runtime_dependency 'jruby-kafka', '1.5.0'
+  s.add_runtime_dependency 'jruby-kafka', '1.6.0'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
This updates 2.0.X to 2.0.5 and updates jruby-kafka which runs Kafka 0.8.2.2 and closes #74 as 0.8.2.2 supports lz4 compression.

Not sure if y'all are planning any updates to 2.X but this will fix that issue.