### PR TITLE
use jruby-kafka v1.6.0 for lz4 support (Close #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.0.5
   - New dependency requirements for logstash-core for the 5.0 release
+  - Update to jruby-kafka 1.6 which includes Kafka 0.8.2.2 enabling LZ4 decompression.
+
 ## 2.0.4
  - Fix safe shutdown while plugin waits on Kafka for new events
  - Expose auto_commit_interval_ms to control offset commit frequency

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
 
-  s.add_runtime_dependency 'jruby-kafka', '1.5.0'
+  s.add_runtime_dependency 'jruby-kafka', '1.6.0'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
This updates jruby-kafka which runs Kafka 0.8.2.2 and closes #74 as 0.8.2.2 supports lz4 compression.