### PR TITLE
convert message_and_metadata.key to ruby string if its not nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.7
+  - Fix issue with `message_and_metadata.key` producing a JRuby ArrayJavaProxy instead of a String or null. Ref: https://github.com/logstash-plugins/logstash-input-kafka/issues/82
+
 # 2.0.6
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.0.5
@@ -10,7 +13,7 @@
  - Fix infinite loop when no new messages are found in Kafka
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Contributors:
 * Richard Pijnenburg (electrical)
 * Suyog Rao (suyograo)
 * Tal Levy (talevy)
+* Guy Boertje (guyboertje)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -179,12 +179,14 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       @codec.decode("#{message_and_metadata.message}") do |event|
         decorate(event)
         if @decorate_events
+          mm_key = message_and_metadata.key
+          kafka_key = mm_key.nil? ? nil : "#{mm_key}"
           event['kafka'] = {'msg_size' => message_and_metadata.message.size,
                             'topic' => message_and_metadata.topic,
                             'consumer_group' => @group_id,
                             'partition' => message_and_metadata.partition,
                             'offset' => message_and_metadata.offset,
-                            'key' => message_and_metadata.key}
+                            'key' => kafka_key}
         end
         output_queue << event
       end # @codec.decode

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-kafka'
-  s.version         = '2.0.6'
+  s.version         = '2.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Reviewers:
- This is to fix the accidental leaking of a org.jruby.java.proxies.ArrayJavaProxy into the Logstash Event.
- I can't test this with a real kafka key that is an array of bytes
- the existing test uses a Ruby class to simulate the Scala MessageAndMetadata class which obviously will not show the fault.

Consider creating a small Java class that implements the Decoder interface as a RubyStringDecoder that creates Ruby Strings directly from the bytes.
