### PR TITLE
Disabling log4j config

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -133,7 +133,6 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   
   public
   def register
-    LogStash::Logger.setup_log4j(@logger)
     @runner_threads = []
   end # def register
 


### PR DESCRIPTION
This setup_log4j hardcodes Log4J setting and cannot be configured.
It is better to use a log4j.properties to silence any errors than
doing this in code.