### PR TITLE
Adding feature for topic regex patterns and also decorate events…

### DIFF
--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -2,7 +2,11 @@
 # Setup Kafka and create test topics
 
 set -ex
-KAFKA_VERSION==0.9.0.1
+if [ -n "${KAFKA_VERSION+1}" ]; then
+  echo "KAFKA_VERSION is $KAFKA_VERSION"
+else
+   KAFKA_VERSION==0.10.0.0
+fi
 
 echo "Downloading Kafka version $KAFKA_VERSION"
 curl -s -o kafka.tgz "http://ftp.wayne.edu/apache/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -14,17 +14,23 @@ mkdir kafka && tar xzf kafka.tgz -C kafka --strip-components 1
 
 echo "Starting ZooKeeper"
 kafka/bin/zookeeper-server-start.sh kafka/config/zookeeper.properties &
+sleep 10
 echo "Starting Kafka broker"
 kafka/bin/kafka-server-start.sh kafka/config/server.properties &
-sleep 3
+sleep 10
 
 echo "Setting up test topics with test data"
-kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_uncompressed --zookeeper localhost:2181
+kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_plain --zookeeper localhost:2181
+sleep 10
 kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_snappy --zookeeper localhost:2181
+sleep 10
 kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_lz4 --zookeeper localhost:2181
 wget https://s3.amazonaws.com/data.elasticsearch.org/apache_logs/apache_logs.txt
-cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_uncompressed --broker-list localhost:9092
+sleep 60
+cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_plain --broker-list localhost:9092
+sleep 10
 cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_snappy --broker-list localhost:9092 --compression-codec snappy
+sleep 10
 cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_lz4 --broker-list localhost:9092 --compression-codec lz4
-
+sleep 10
 echo "Setup complete, running specs"

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -2,6 +2,7 @@
 # Setup Kafka and create test topics
 
 set -ex
+KAFKA_VERSION==0.9.0.1
 
 echo "Downloading Kafka version $KAFKA_VERSION"
 curl -s -o kafka.tgz "http://ftp.wayne.edu/apache/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
@@ -14,12 +15,12 @@ kafka/bin/kafka-server-start.sh kafka/config/server.properties &
 sleep 3
 
 echo "Setting up test topics with test data"
-kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic topic3 --zookeeper localhost:2181
-kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic snappy_topic --zookeeper localhost:2181
-kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic lz4_topic --zookeeper localhost:2181
+kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_uncompressed --zookeeper localhost:2181
+kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_snappy --zookeeper localhost:2181
+kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_lz4 --zookeeper localhost:2181
 wget https://s3.amazonaws.com/data.elasticsearch.org/apache_logs/apache_logs.txt
-cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic topic3 --broker-list localhost:9092
-cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic snappy_topic --broker-list localhost:9092 --compression-codec snappy
-cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic lz4_topic --broker-list localhost:9092 --compression-codec lz4
+cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_uncompressed --broker-list localhost:9092
+cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_snappy --broker-list localhost:9092 --compression-codec snappy
+cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_lz4 --broker-list localhost:9092 --compression-codec lz4
 
 echo "Setup complete, running specs"

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -5,7 +5,7 @@ set -ex
 if [ -n "${KAFKA_VERSION+1}" ]; then
   echo "KAFKA_VERSION is $KAFKA_VERSION"
 else
-   KAFKA_VERSION==0.10.0.0
+   KAFKA_VERSION=0.10.0.0
 fi
 
 echo "Downloading Kafka version $KAFKA_VERSION"

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -123,8 +123,11 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :session_timeout_ms, :validate => :string
   # Java Class used to deserialize the record's value
   config :value_deserializer_class, :validate => :string, :default => "org.apache.kafka.common.serialization.StringDeserializer"
-  # A list of topics to subscribe to.
-  config :topics, :validate => :array, :required => true
+  # A list of topics to subscribe to, defaults to ["logstash"].
+  config :topics, :validate => :array, :default => ["logstash"]
+  # A topic regex pattern to subscribe to. 
+  # The topics configuration will be ignored when using this configuration.
+  config :topics_pattern, :validate => :string
   # Time kafka consumer will wait to receive new messages from topics
   config :poll_timeout_ms, :validate => :number
   # Enable SSL/TLS secured communication to Kafka broker.
@@ -137,6 +140,14 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :ssl_keystore_location, :validate => :path
   # If client authentication is required, this setting stores the keystore password
   config :ssl_keystore_password, :validate => :password
+  # Option to add Kafka metadata like topic, message size to the event.
+  # This will add a field named `kafka` to the logstash event containing the following attributes:
+  #   `topic`: The topic this message is associated with
+  #   `consumer_group`: The consumer group used to read in this event
+  #   `partition`: The partition this message is associated with
+  #   `offset`: The offset from the partition this message is associated with
+  #   `key`: A ByteBuffer containing the message key
+  config :decorate_events, :validate => :boolean, :default => false
 
 
   public
@@ -161,12 +172,25 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   def thread_runner(logstash_queue, consumer)
     Thread.new do
       begin
-        consumer.subscribe(topics);
+        unless @topics_pattern.nil?
+          nooplistener = org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener.new
+          pattern = java.util.regex.Pattern.compile(@topics_pattern)
+          consumer.subscribe(pattern, nooplistener)
+        else
+          consumer.subscribe(topics);
+        end
         while !stop?
           records = consumer.poll(poll_timeout_ms);
           for record in records do
             @codec.decode(record.value.to_s) do |event|
               decorate(event)
+              if @decorate_events
+                event.set("[kafka][topic]", record.topic)
+                event.set("[kafka][consumer_group]", @group_id)
+                event.set("[kafka][partition]", record.partition)
+                event.set("[kafka][offset]", record.offset)
+                event.set("[kafka][key]", record.key)
+              end
               logstash_queue << event
             end
           end

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -13,7 +13,7 @@ describe "inputs/kafka", :integration => true do
     let(:snappy_config) { { 'topics' => ['logstash_topic_snappy'], 'codec' => 'plain', 'group_id' => group_id, 'auto_offset_reset' => 'earliest'} }
     let(:lz4_config) { { 'topics' => ['logstash_topic_lz4'], 'codec' => 'plain', 'group_id' => group_id, 'auto_offset_reset' => 'earliest'} }
     
-    let(:timeout_seconds) { 3600 }
+    let(:timeout_seconds) { 120 }
     let(:num_events) { 103 }
     
     def thread_it(kafka_input, queue)
@@ -56,7 +56,7 @@ describe "inputs/kafka", :integration => true do
   describe "#kafka-topics-pattern" do
     let(:group_id) {rand(36**8).to_s(36)}
     let(:pattern_config) { { 'topics_pattern' => 'logstash_topic_.*', 'group_id' => group_id, 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }  
-    let(:timeout_seconds) { 3600 }
+    let(:timeout_seconds) { 120 }
     let(:num_events) { 309 }
     
     def thread_it(kafka_input, queue)
@@ -81,7 +81,7 @@ describe "inputs/kafka", :integration => true do
     let(:group_id) {rand(36**8).to_s(36)}
     let(:topic) {"logstash_topic_uncompressed"}
     let(:partition3_config) { { 'topics' => [topic], 'group_id' => group_id, 'codec' => 'plain', 'auto_offset_reset' => 'earliest', 'decorate_events' => true} }    
-    let(:timeout_seconds) { 3600 }
+    let(:timeout_seconds) { 120 }
     let(:num_events) { 103 }
     
     def thread_it(kafka_input, queue)

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -4,47 +4,104 @@ require "logstash/inputs/kafka"
 require "digest"
 require "rspec/wait"
 
-describe "input/kafka", :integration => true do
-  let(:partition3_config) { { 'topics' => ['topic3'], 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }
-  let(:snappy_config) { { 'topics' => ['snappy_topic'], 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }
-  let(:lz4_config) { { 'topics' => ['lz4_topic'], 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }
-  
-  let(:timeout_seconds) { 3600 }
-  let(:num_events) { 103 }
-  
-  def thread_it(kafka_input, queue)
-    Thread.new do
-      begin
-        kafka_input.run(queue)
+# Please run kafka_test_setup.sh prior to executing this integration test.
+describe "inputs/kafka", :integration => true do
+
+  describe "#kafka-topics" do
+    let(:group_id) {rand(36**8).to_s(36)}
+    let(:partition3_config) { { 'topics' => ['logstash_topic_uncompressed'], 'codec' => 'plain', 'group_id' => group_id, 'auto_offset_reset' => 'earliest'} }
+    let(:snappy_config) { { 'topics' => ['logstash_topic_snappy'], 'codec' => 'plain', 'group_id' => group_id, 'auto_offset_reset' => 'earliest'} }
+    let(:lz4_config) { { 'topics' => ['logstash_topic_lz4'], 'codec' => 'plain', 'group_id' => group_id, 'auto_offset_reset' => 'earliest'} }
+    
+    let(:timeout_seconds) { 10 }
+    let(:num_events) { 103 }
+    
+    def thread_it(kafka_input, queue)
+      Thread.new do
+        begin
+          kafka_input.run(queue)
+        end
       end
     end
-  end
+      
+    it "should consume all messages from 3-partition topic" do
+      kafka_input = LogStash::Inputs::Kafka.new(partition3_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+    end
     
-  it "should consume all messages from 3-partition topic" do
-    kafka_input = LogStash::Inputs::Kafka.new(partition3_config)
-    queue = Array.new
-    t = thread_it(kafka_input, queue)
-    t.run
-    wait(timeout_seconds).for { queue.length }.to eq(num_events)
-    expect(queue.length).to eq(num_events)
-  end
-  
-  it "should consume all messages from snappy 3-partition topic" do
-    kafka_input = LogStash::Inputs::Kafka.new(snappy_config)
-    queue = Array.new
-    t = thread_it(kafka_input, queue)
-    t.run
-    wait(timeout_seconds).for { queue.length }.to eq(num_events)
-    expect(queue.length).to eq(num_events)
+    it "should consume all messages from snappy 3-partition topic" do
+      kafka_input = LogStash::Inputs::Kafka.new(snappy_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+    end
+
+    it "should consume all messages from lz4 3-partition topic" do
+      kafka_input = LogStash::Inputs::Kafka.new(lz4_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+    end
+    
   end
 
-  it "should consume all messages from lz4 3-partition topic" do
-    kafka_input = LogStash::Inputs::Kafka.new(lz4_config)
-    queue = Array.new
-    t = thread_it(kafka_input, queue)
-    t.run
-    wait(timeout_seconds).for { queue.length }.to eq(num_events)
-    expect(queue.length).to eq(num_events)
+  describe "#kafka-topics-pattern" do
+    let(:group_id) {rand(36**8).to_s(36)}
+    let(:pattern_config) { { 'topics_pattern' => 'logstash_topic_.*', 'group_id' => group_id, 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }  
+    let(:timeout_seconds) { 10 }
+    let(:num_events) { 309 }
+    
+    def thread_it(kafka_input, queue)
+      Thread.new do
+        begin
+          kafka_input.run(queue)
+        end
+      end
+    end
+      
+    it "should consume all messages from all 3 topics" do
+      kafka_input = LogStash::Inputs::Kafka.new(pattern_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+    end    
   end
-  
+
+  describe "#kafka-decorate" do
+    let(:group_id) {rand(36**8).to_s(36)}
+    let(:topic) {"logstash_topic_uncompressed"}
+    let(:partition3_config) { { 'topics' => [topic], 'group_id' => group_id, 'codec' => 'plain', 'auto_offset_reset' => 'earliest', 'decorate_events' => true} }    
+    let(:timeout_seconds) { 10 }
+    let(:num_events) { 103 }
+    
+    def thread_it(kafka_input, queue)
+      Thread.new do
+        begin
+          kafka_input.run(queue)
+        end
+      end
+    end
+      
+    it "should show the right topic name in decorate" do
+      kafka_input = LogStash::Inputs::Kafka.new(partition3_config)
+      queue = Queue.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+      event = queue.shift
+      expect(event.get("kafka")["topic"]).to eq(topic)
+      expect(event.get("kafka")["consumer_group"]).to eq(group_id)
+    end
+  end
 end

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -13,7 +13,7 @@ describe "inputs/kafka", :integration => true do
     let(:snappy_config) { { 'topics' => ['logstash_topic_snappy'], 'codec' => 'plain', 'group_id' => group_id, 'auto_offset_reset' => 'earliest'} }
     let(:lz4_config) { { 'topics' => ['logstash_topic_lz4'], 'codec' => 'plain', 'group_id' => group_id, 'auto_offset_reset' => 'earliest'} }
     
-    let(:timeout_seconds) { 10 }
+    let(:timeout_seconds) { 3600 }
     let(:num_events) { 103 }
     
     def thread_it(kafka_input, queue)
@@ -56,7 +56,7 @@ describe "inputs/kafka", :integration => true do
   describe "#kafka-topics-pattern" do
     let(:group_id) {rand(36**8).to_s(36)}
     let(:pattern_config) { { 'topics_pattern' => 'logstash_topic_.*', 'group_id' => group_id, 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }  
-    let(:timeout_seconds) { 10 }
+    let(:timeout_seconds) { 3600 }
     let(:num_events) { 309 }
     
     def thread_it(kafka_input, queue)
@@ -81,7 +81,7 @@ describe "inputs/kafka", :integration => true do
     let(:group_id) {rand(36**8).to_s(36)}
     let(:topic) {"logstash_topic_uncompressed"}
     let(:partition3_config) { { 'topics' => [topic], 'group_id' => group_id, 'codec' => 'plain', 'auto_offset_reset' => 'earliest', 'decorate_events' => true} }    
-    let(:timeout_seconds) { 10 }
+    let(:timeout_seconds) { 3600 }
     let(:num_events) { 103 }
     
     def thread_it(kafka_input, queue)

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -56,7 +56,7 @@ describe "inputs/kafka", :integration => true do
   describe "#kafka-topics-pattern" do
     let(:group_id) {rand(36**8).to_s(36)}
     let(:pattern_config) { { 'topics_pattern' => 'logstash_topic_.*', 'group_id' => group_id, 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }  
-    let(:timeout_seconds) { 120 }
+    let(:timeout_seconds) { 300 }
     let(:num_events) { 309 }
     
     def thread_it(kafka_input, queue)
@@ -81,7 +81,7 @@ describe "inputs/kafka", :integration => true do
     let(:group_id) {rand(36**8).to_s(36)}
     let(:topic) {"logstash_topic_uncompressed"}
     let(:partition3_config) { { 'topics' => [topic], 'group_id' => group_id, 'codec' => 'plain', 'auto_offset_reset' => 'earliest', 'decorate_events' => true} }    
-    let(:timeout_seconds) { 120 }
+    let(:timeout_seconds) { 300 }
     let(:num_events) { 103 }
     
     def thread_it(kafka_input, queue)
@@ -92,7 +92,7 @@ describe "inputs/kafka", :integration => true do
       end
     end
       
-    it "should show the right topic name in decorate" do
+    it "should show the right topic and group name in decorated kafka section" do
       kafka_input = LogStash::Inputs::Kafka.new(partition3_config)
       queue = Queue.new
       t = thread_it(kafka_input, queue)

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -16,7 +16,7 @@ class MockConsumer
       raise org.apache.kafka.common.errors.WakeupException.new
     else
       10.times.map do
-        org.apache.kafka.clients.consumer.ConsumerRecord.new("test", 0, 0, "key", "value")
+        org.apache.kafka.clients.consumer.ConsumerRecord.new("logstash", 0, 0, "key", "value")
       end
     end
   end

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -30,7 +30,7 @@ class MockConsumer
 end
 
 describe LogStash::Inputs::Kafka do
-  let(:config) { { 'topics' => ['test'], 'consumer_threads' => 4 } }
+  let(:config) { { 'topics' => ['logstash'], 'consumer_threads' => 4 } }
   subject { LogStash::Inputs::Kafka.new(config) }
 
   it "should register" do


### PR DESCRIPTION
Two features that were useful in the older plugin have been added.
Using the new consumer and adding support for regex patterns as topics_pattern.
Adding the Kafka metadata decorate option which provides data on topic, partition where the message is  consumed from.
