### PR TITLE
Make error reporting more clear when connection fails

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -259,7 +259,9 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
       org.apache.kafka.clients.consumer.KafkaConsumer.new(props)
     rescue => e
-      logger.error("Unable to create Kafka consumer from given configuration", :kafka_error_message => e)
+      logger.error("Unable to create Kafka consumer from given configuration",
+                   :kafka_error_message => e,
+                   :cause => e.respond_to?(:getCause) ? e.getCause() : nil)
       throw e
     end
   end


### PR DESCRIPTION
When the kafka connection fails, Logstash hides the cause of the failure making fixing it quite difficult.

The log looks like this, regardless of the underlying problem (DNS, network, auth, etc):
`{:timestamp=>"2016-07-21T12:57:49.759000+0000", :message=>"Unable to create Kafka consumer from given configuration", :kafka_error_message=>org.apache.kafka.common.KafkaException: Failed to construct kafka consumer, :level=>:error}`

This pull request brings in more information from the cause set on the KafkaException, so the log looks like this:
`{:timestamp=>"2016-07-21T12:57:48.753000+0000", :message=>"Unable to create Kafka consumer from given configuration", :kafka_error_message=>org.apache.kafka.common.KafkaException: Failed to construct kafka consumer, :cause=>org.apache.kafka.common.config.ConfigException: DNS resolution failed for url in bootstrap.servers: invalid.efesfse.com:9200, :level=>:error}`

Or like this:
`{:timestamp=>"2016-07-21T12:56:08.149000+0000", :message=>"Unable to create Kafka consumer from given configuration", :kafka_error_message=>org.apache.kafka.common.KafkaException: Failed to construct kafka consumer, :cause=>org.apache.kafka.common.config.ConfigException: Invalid url in bootstrap.servers: invalid, :level=>:error}`

I contemplated adding a test here, but testing that log messages are produced isn't generally recommended. If we do want a test case, its likely it wouldn't be a pretty one as we'd need to mock the logger in some way, or add a custom consumer, but I'm open to it if required.
