### PR TITLE
Adds dual.commit.enabled and offsets.storage

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -94,6 +94,10 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :decoder_class, :validate => :string, :default => 'kafka.serializer.DefaultDecoder'
   # The serializer class for keys (defaults to the same default as for messages)
   config :key_decoder_class, :validate => :string, :default => 'kafka.serializer.DefaultDecoder'
+  # If you are using "kafka" as offsets.storage, you can dual commit offsets to ZooKeeper (in addition to Kafka)
+  config :dual_commit_enabled, :validate => :boolean, :default => true
+  # Select where offsets should be stored (zookeeper or kafka)
+  config :offsets_storage, :validate => :string, :default => "zookeeper"
 
   class KafkaShutdownEvent; end
   KAFKA_SHUTDOWN_EVENT = KafkaShutdownEvent.new
@@ -117,7 +121,9 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         :allow_topics => @white_list,
         :filter_topics => @black_list,
         :value_decoder_class => @decoder_class,
-        :key_decoder_class => @key_decoder_class
+        :key_decoder_class => @key_decoder_class,
+        :dual_commit_enabled => @dual_commit_enabled,
+        :offsets_storage => @offsets_storage
     }
     if @reset_beginning
       options[:reset_beginning] = 'from-beginning'


### PR DESCRIPTION
- Depends on https://github.com/joekiller/jruby-kafka/pull/54
- http://fr.slideshare.net/jjkoshy/offset-management-in-kafka slide 34
- https://cwiki.apache.org/confluence/display/KAFKA/FAQ#FAQ-HowdowemigratetocommittingoffsetstoKafka(ratherthanZookeeper)in0.8.2
