### PR TITLE
Alias `rake vendor` to `rake install_jars`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,3 +13,5 @@ task :install_jars do
   ENV['JARS_VENDOR'] = "false"
   Jars::Installer.new.vendor_jars!(false)
 end
+
+task :vendor => :install_jars


### PR DESCRIPTION
Our bot jarvis and documentation generator assume a few commands to make
a plugin ready to be used.

- bundle install
- bundle exec rake vendor

This PR make sure that this workflow still work with the jars