### PR TITLE
cleanup gem lib files to only include ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ env:
 before_install: ./kafka_test_setup.sh
 before_script:
   - bundle exec rake vendor
-  - bundle exec rake install_jars
 script: bundle exec rspec && bundle exec rspec --tag integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.3
+  - Internal: gem cleanup
+
 ## 5.0.2
   - Release a new version of the gem that includes jars
 

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '5.0.2'
+  s.version         = '5.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*.rb','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION

- only include ruby files from the `lib` directory into the gem
- no need to run `install_jars` after vendor in the .travis.yml