### PR TITLE
logstash 5.0 no longer has setup_log4j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.5
+  - place setup_log4j for logging registration behind version check
+
 ## 5.0.4
   - Update to Kafka version 0.10.0.1 for bug fixes
 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -166,7 +166,11 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   public
   def register
-    LogStash::Logger.setup_log4j(@logger)
+    # Logstash 2.4
+    if defined?(LogStash::Logger) && LogStash::Logger.respond_to?(:setup_log4j)
+      LogStash::Logger.setup_log4j(@logger)
+    end
+
     @runner_threads = []
   end # def register
 
@@ -260,7 +264,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
       org.apache.kafka.clients.consumer.KafkaConsumer.new(props)
     rescue => e
-      logger.error("Unable to create Kafka consumer from given configuration", :kafka_error_message => e)
+      @logger.error("Unable to create Kafka consumer from given configuration", :kafka_error_message => e)
       throw e
     end
   end


### PR DESCRIPTION

keep it here since this can still be installed on LS 2.4