### PR TITLE
Add optional client parameter: ssl_key_password (kafka >= 0.9)

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -150,6 +150,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :ssl_truststore_location, :validate => :path
   # The truststore password
   config :ssl_truststore_password, :validate => :password
+  # Password of the private key in the key store for client authentication if needed.
+  config :ssl_key_password, :validate => :password
   # If client authentication is required, this setting stores the keystore path.
   config :ssl_keystore_location, :validate => :path
   # If client authentication is required, this setting stores the keystore password
@@ -258,6 +260,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         props.put("ssl.truststore.password", ssl_truststore_password.value) unless ssl_truststore_password.nil?
 
         #Client auth stuff
+        props.put("ssl.key.password", ssl_key_password.value) unless ssl_key_password.nil?
         props.put("ssl.keystore.location", ssl_keystore_location) unless ssl_keystore_location.nil?
         props.put("ssl.keystore.password", ssl_keystore_password.value) unless ssl_keystore_password.nil?
       end

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '5.0.5'
+  s.version         = '5.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.email           = 'info@elastic.co'
   s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
   s.require_paths = ['lib']
+  s.platform = "java"
 
   # Files
   s.files = Dir['lib/**/*.rb','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
@@ -32,4 +33,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rspec-wait'
 end
-


### PR DESCRIPTION
Hello, since kafka version 0.9 the consumer configuration for two-way authentication has the parameter: [ssl.key.password](http://kafka.apache.org/documentation.html#newconsumerconfigs), that cause an weird error if not defined, even if your private key in the key store don't needs password, what is my case.

So to solve my problem, I pass an empty password to kafka consumer configuration doing the following in the plugin:

``` ruby
config :ssl_key_password, :validate => :password
...
props.put("ssl.key.password", ssl_key_password.value) unless ssl_key_password.nil?
```

and:

```
kafka {
      ...
      ssl => true
      ssl_truststore_location => "/var/private/ssl/logstash.truststore.jks"
      ssl_truststore_password => "someOtherPassword"
      ssl_key_password => ""
      ssl_keystore_location => "/var/private/ssl/logstash.keystore.jks"
      ssl_keystore_password => "somePassword"
      ...
   }
```

In case this be useful for someone, I open this PR to allow two-way ssl configuration with private key password in key store.
