### PR TITLE
remove logstash setup_log4j support, this breaks external configuration files

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -166,11 +166,6 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   public
   def register
-    # Logstash 2.4
-    if defined?(LogStash::Logger) && LogStash::Logger.respond_to?(:setup_log4j)
-      LogStash::Logger.setup_log4j(@logger)
-    end
-
     @runner_threads = []
   end # def register
 


### PR DESCRIPTION
https://github.com/elastic/logstash/issues/6361 exposes the fact that setting a custom 
log4j configuration file in Logstash 2.4 is invalidated by this plugin's decision to setup log4j if it is in the 2.4 context.

`setup_log4j` overrides any of these system properties provided and ignores it.