### PR TITLE
set kerberos only when using GSSAPI

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -336,8 +336,9 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
     props.put("sasl.mechanism",sasl_mechanism)
     if sasl_mechanism == "GSSAPI" && sasl_kerberos_service_name.nil?
       raise LogStash::ConfigurationError, "sasl_kerberos_service_name must be specified when SASL mechanism is GSSAPI"
+    elsif sasl_mechanism == "GSSAPI"
+      props.put("sasl.kerberos.service.name",sasl_kerberos_service_name)
     end
-
-    props.put("sasl.kerberos.service.name",sasl_kerberos_service_name)
+    
   end
 end #class LogStash::Inputs::Kafka


### PR DESCRIPTION
`sasl_kerberos_service_name` should not be referenced when using Kafka with SASL_PLAIN. Otherwise the plugin would crash with `java.lang.NullPointerException` since `sasl_kerberos_service_name` is usually left unchanged(nil) when using SASL_PLAIN.
