### PR TITLE
bump kafka dependency to 0.10.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.2.2
+  - update kafka-clients dependency to 0.10.1.1
+
 ## 6.2.1
   - Docs: Clarify compatibility matrix and remove it from the changelog to avoid duplication.
   

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -5,7 +5,7 @@ set -ex
 if [ -n "${KAFKA_VERSION+1}" ]; then
   echo "KAFKA_VERSION is $KAFKA_VERSION"
 else
-   KAFKA_VERSION=0.10.1.0
+   KAFKA_VERSION=0.10.1.1
 fi
 
 echo "Downloading Kafka version $KAFKA_VERSION"

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '6.2.1'
+  s.version         = '6.2.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { 'logstash_plugin' => 'true', 'group' => 'input'}
 
-  s.requirements << "jar 'org.apache.kafka:kafka-clients', '0.10.1.0'"
+  s.requirements << "jar 'org.apache.kafka:kafka-clients', '0.10.1.1'"
   s.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.21'"
 
   s.add_development_dependency 'jar-dependencies', '~> 0.3.2'


### PR DESCRIPTION
Kafka Release Notes:
`https://archive.apache.org/dist/kafka/0.10.1.1/RELEASE_NOTES.html.`

Closes #159.