### PR TITLE
bump version and fix log4j bootstrapping for LS 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.4
+  - Fix log4j bootstrapping for 2.4
+
 ## 5.1.3
   - Make error reporting clearer when connection fails
   - set kerberos only when using GSSAPI

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -204,11 +204,6 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   public
   def register
-    # Logstash 2.4
-    if defined?(LogStash::Logger) && LogStash::Logger.respond_to?(:setup_log4j)
-      LogStash::Logger.setup_log4j(@logger)
-    end
-
     @runner_threads = []
   end # def register
 

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '5.1.3'
+  s.version         = '5.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
https://github.com/elastic/logstash/issues/6361 exposes the fact that setting a custom

log4j configuration file in Logstash 2.4 is invalidated by this plugin's decision
to setup log4j if it is in the 2.4 context.

`setup_log4j` overrides any of these system properties provided and ignores it.
