### PR TITLE
backport(5.x): Client ID should not be reused across multiple Kafka consumer instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.6
+  - fix: Client ID is no longer reused across multiple Kafka consumer instances
+
 ## 5.1.5
   - Fix a bug where consumer was not correctly setup when `SASL_SSL` option was specified. 
 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -209,7 +209,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   public
   def run(logstash_queue)
-    @runner_consumers = consumer_threads.times.map { || create_consumer }
+    @runner_consumers = consumer_threads.times.map { |i| create_consumer("#{client_id}-#{i}") }
     @runner_threads = @runner_consumers.map { |consumer| thread_runner(logstash_queue, consumer) }
     @runner_threads.each { |t| t.join }
   end # def run
@@ -217,6 +217,11 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   public
   def stop
     @runner_consumers.each { |c| c.wakeup }
+  end
+
+  public
+  def kafka_consumers
+    @runner_consumers
   end
 
   private
@@ -255,7 +260,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   end
 
   private
-  def create_consumer
+  def create_consumer(client_id)
     begin
       props = java.util.Properties.new
       kafka = org.apache.kafka.clients.consumer.ConsumerConfig

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '5.1.5'
+  s.version         = '5.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
backport of #169.