### PR TITLE
logstash core removed the log4j1.2 api compatibility, this brings it back for this plugin

### DIFF
--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.requirements << "jar 'org.apache.kafka:kafka-clients', '0.10.1.1'"
   s.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.21'"
+  s.requirements << "jar 'org.apache.logging.log4j:log4j-1.2-api', '2.6.2'"
 
   s.add_development_dependency 'jar-dependencies', '~> 0.3.2'
 


### PR DESCRIPTION
Logging broke in the later versions of Logstash `5.x (x > 0)` for this plugin.

core removal commit: https://github.com/elastic/logstash/commit/8dfefad58a1d5257016b1225994abfed2306d8ca