### PR TITLE
Adding feature for topic regex patterns and also decorate events… (#103)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,13 @@
 sudo: false
 language: ruby
 cache: bundler
-jdk:
-  - oraclejdk8
+jdk: oraclejdk8
 rvm:
   - jruby-1.7.25
-before_install:
-  - curl -s -o kafka.tgz http://ftp.wayne.edu/apache/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz
-  - mkdir kafka && tar xzf kafka.tgz -C kafka --strip-components 1
-  - kafka/bin/zookeeper-server-start.sh kafka/config/zookeeper.properties &
-  - kafka/bin/kafka-server-start.sh kafka/config/server.properties &
-  - sleep 3
-  - kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic topic3 --zookeeper localhost:2181
-  - kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic snappy_topic --zookeeper localhost:2181
-  - kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic lz4_topic --zookeeper localhost:2181
-  - wget https://s3.amazonaws.com/data.elasticsearch.org/apache_logs/apache_logs.txt
-  - cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic topic3 --broker-list localhost:9092
-  - cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic snappy_topic --broker-list localhost:9092 --compression-codec snappy
-  - cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic lz4_topic --broker-list localhost:9092 --compression-codec lz4
+env:
+  - KAFKA_VERSION=0.9.0.0
+before_install: ./kafka_test_setup.sh
 before_script:
   - bundle exec rake vendor
-  - bundle exec rake install_jars
 script: bundle exec rspec && bundle exec rspec --tag integration
+after_script: ./kafka_test_teardown.sh

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+
+set -ex
+if [ -n "${KAFKA_VERSION+1}" ]; then
+  echo "KAFKA_VERSION is $KAFKA_VERSION"
+else
+   KAFKA_VERSION=0.9.0.0
+fi
+
+echo "Downloading Kafka version $KAFKA_VERSION"
+curl -s -o kafka.tgz "http://ftp.wayne.edu/apache/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
+mkdir kafka && tar xzf kafka.tgz -C kafka --strip-components 1
+
+echo "Starting ZooKeeper"
+kafka/bin/zookeeper-server-start.sh kafka/config/zookeeper.properties &
+sleep 10
+echo "Starting Kafka broker"
+kafka/bin/kafka-server-start.sh kafka/config/server.properties &
+sleep 10
+
+echo "Setting up test topics with test data"
+kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_plain --zookeeper localhost:2181
+sleep 10
+kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_snappy --zookeeper localhost:2181
+sleep 10
+kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_lz4 --zookeeper localhost:2181
+wget https://s3.amazonaws.com/data.elasticsearch.org/apache_logs/apache_logs.txt
+sleep 60
+cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_plain --broker-list localhost:9092
+sleep 10
+cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_snappy --broker-list localhost:9092 --compression-codec snappy
+sleep 10
+cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_lz4 --broker-list localhost:9092 --compression-codec lz4
+sleep 10
+echo "Setup complete, running specs"

--- a/kafka_test_teardown.sh
+++ b/kafka_test_teardown.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+
+set -ex
+
+echo "Stopping Kafka broker"
+kafka/bin/kafka-server-stop.sh
+echo "Stopping zookeeper"
+kafka/bin/zookeeper-server-stop.sh

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -114,8 +114,11 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :session_timeout_ms, :validate => :string, :default => "30000"
   # Java Class used to deserialize the record's value
   config :value_deserializer_class, :validate => :string, :default => "org.apache.kafka.common.serialization.StringDeserializer"
-  # A list of topics to subscribe to.
-  config :topics, :validate => :array, :required => true
+  # A list of topics to subscribe to, defaults to ["logstash"].
+  config :topics, :validate => :array, :default => ["logstash"]
+  # A topic regex pattern to subscribe to. 
+  # The topics configuration will be ignored when using this configuration.
+  config :topics_pattern, :validate => :string
   # Time kafka consumer will wait to receive new messages from topics
   config :poll_timeout_ms, :validate => :number, :default => 100
   # Enable SSL/TLS secured communication to Kafka broker. Note that secure communication 
@@ -129,6 +132,14 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :ssl_keystore_location, :validate => :path
   # If client authentication is required, this setting stores the keystore password
   config :ssl_keystore_password, :validate => :password
+  # Option to add Kafka metadata like topic, message size to the event.
+  # This will add a field named `kafka` to the logstash event containing the following attributes:
+  #   `topic`: The topic this message is associated with
+  #   `consumer_group`: The consumer group used to read in this event
+  #   `partition`: The partition this message is associated with
+  #   `offset`: The offset from the partition this message is associated with
+  #   `key`: A ByteBuffer containing the message key
+  config :decorate_events, :validate => :boolean, :default => false
 
   
   public
@@ -156,12 +167,25 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   def thread_runner(logstash_queue, consumer)
     Thread.new do
       begin
-        consumer.subscribe(topics);
+        unless @topics_pattern.nil?
+          nooplistener = org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener.new
+          pattern = java.util.regex.Pattern.compile(@topics_pattern)
+          consumer.subscribe(pattern, nooplistener)
+        else
+          consumer.subscribe(topics);
+        end
         while !stop?
           records = consumer.poll(poll_timeout_ms);
           for record in records do
             @codec.decode(record.value.to_s) do |event|
               decorate(event)
+              if @decorate_events
+                event.set("[kafka][topic]", record.topic)
+                event.set("[kafka][consumer_group]", @group_id)
+                event.set("[kafka][partition]", record.partition)
+                event.set("[kafka][offset]", record.offset)
+                event.set("[kafka][key]", record.key)
+              end
               logstash_queue << event
             end
           end

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -2,59 +2,111 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/kafka"
 require "digest"
+require "rspec/wait"
 
-describe "input/kafka", :integration => true do
-  let(:partition3_config) { { 'topics' => ['topic3'], 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }
-  let(:snappy_config) { { 'topics' => ['snappy_topic'], 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }
-  let(:lz4_config) { { 'topics' => ['lz4_topic'], 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }
-  
-  let(:tries) { 60 }
+# Please run kafka_test_setup.sh prior to executing this integration test.
+describe "inputs/kafka", :integration => true do
+  # Group ids to make sure that the consumers get all the logs.
+  let(:group_id_1) {rand(36**8).to_s(36)}
+  let(:group_id_2) {rand(36**8).to_s(36)}
+  let(:group_id_3) {rand(36**8).to_s(36)}
+  let(:group_id_4) {rand(36**8).to_s(36)}
+  let(:plain_config) { { 'topics' => ['logstash_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
+  let(:multi_consumer_config) { plain_config.merge({"group_id" => group_id_4, "client_id" => "spec", "consumer_threads" => 3}) }
+  let(:snappy_config) { { 'topics' => ['logstash_topic_snappy'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
+  let(:lz4_config) { { 'topics' => ['logstash_topic_lz4'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
+  let(:pattern_config) { { 'topics_pattern' => 'logstash_topic_.*', 'group_id' => group_id_2, 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }  
+  let(:decorate_config) { { 'topics' => ['logstash_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_3, 'auto_offset_reset' => 'earliest', 'decorate_events' => true} }
+  let(:timeout_seconds) { 120 }
   let(:num_events) { 103 }
-  
-  def thread_it(kafka_input, queue)
-    Thread.new do
-      begin
-        kafka_input.run(queue)
-      end
-    end
-  end
-  
-  def wait_for_events(queue, num_events)
-    begin
-      timeout(30) do
-        until queue.length == num_events do
-          sleep 1
-          next
+
+  describe "#kafka-topics" do
+    def thread_it(kafka_input, queue)
+      Thread.new do
+        begin
+          kafka_input.run(queue)
         end
       end
     end
-  end  
-    
-  it "should consume all messages from 3-partition topic" do
-    kafka_input = LogStash::Inputs::Kafka.new(partition3_config)
-    queue = Array.new
-    t = thread_it(kafka_input, queue)
-    t.run
-    wait_for_events(queue, num_events)
-    expect(queue.size).to eq(num_events)
-  end
-  
-  it "should consume all messages from snappy 3-partition topic" do
-    kafka_input = LogStash::Inputs::Kafka.new(snappy_config)
-    queue = Array.new
-    t = thread_it(kafka_input, queue)
-    t.run
-    wait_for_events(queue, num_events)
-    expect(queue.size).to eq(num_events)
+
+    it "should consume all messages from plain 3-partition topic" do
+      kafka_input = LogStash::Inputs::Kafka.new(plain_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+    end
+
+    it "should consume all messages from snappy 3-partition topic" do
+      kafka_input = LogStash::Inputs::Kafka.new(snappy_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+    end
+
+    it "should consume all messages from lz4 3-partition topic" do
+      kafka_input = LogStash::Inputs::Kafka.new(lz4_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+    end
+
+    it "should consumer all messages with multiple consumers" do
+      kafka_input = LogStash::Inputs::Kafka.new(multi_consumer_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+      kafka_input.kafka_consumers.each_with_index do |consumer, i|
+        expect(consumer.metrics.keys.first.tags["client-id"]).to eq("spec-#{i}")
+      end
+    end
   end
 
-  it "should consume all messages from lz4 3-partition topic" do
-    kafka_input = LogStash::Inputs::Kafka.new(lz4_config)
-    queue = Array.new
-    t = thread_it(kafka_input, queue)
-    t.run
-    wait_for_events(queue, num_events)
-    expect(queue.size).to eq(num_events)
+  describe "#kafka-topics-pattern" do
+    def thread_it(kafka_input, queue)
+      Thread.new do
+        begin
+          kafka_input.run(queue)
+        end
+      end
+    end
+
+    it "should consume all messages from all 3 topics" do
+      kafka_input = LogStash::Inputs::Kafka.new(pattern_config)
+      queue = Array.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(3*num_events)
+      expect(queue.length).to eq(3*num_events)
+    end
   end
-  
+
+  describe "#kafka-decorate" do
+    def thread_it(kafka_input, queue)
+      Thread.new do
+        begin
+          kafka_input.run(queue)
+        end
+      end
+    end
+
+    it "should show the right topic and group name in decorated kafka section" do
+      kafka_input = LogStash::Inputs::Kafka.new(decorate_config)
+      queue = Queue.new
+      t = thread_it(kafka_input, queue)
+      t.run
+      wait(timeout_seconds).for { queue.length }.to eq(num_events)
+      expect(queue.length).to eq(num_events)
+      event = queue.shift
+      expect(event.get("kafka")["topic"]).to eq("logstash_topic_plain")
+      expect(event.get("kafka")["consumer_group"]).to eq(group_id_3)
+    end
+  end
 end

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -10,9 +10,7 @@ describe "inputs/kafka", :integration => true do
   let(:group_id_1) {rand(36**8).to_s(36)}
   let(:group_id_2) {rand(36**8).to_s(36)}
   let(:group_id_3) {rand(36**8).to_s(36)}
-  let(:group_id_4) {rand(36**8).to_s(36)}
   let(:plain_config) { { 'topics' => ['logstash_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
-  let(:multi_consumer_config) { plain_config.merge({"group_id" => group_id_4, "client_id" => "spec", "consumer_threads" => 3}) }
   let(:snappy_config) { { 'topics' => ['logstash_topic_snappy'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
   let(:lz4_config) { { 'topics' => ['logstash_topic_lz4'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
   let(:pattern_config) { { 'topics_pattern' => 'logstash_topic_.*', 'group_id' => group_id_2, 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }  
@@ -55,21 +53,11 @@ describe "inputs/kafka", :integration => true do
       wait(timeout_seconds).for { queue.length }.to eq(num_events)
       expect(queue.length).to eq(num_events)
     end
-
-    it "should consumer all messages with multiple consumers" do
-      kafka_input = LogStash::Inputs::Kafka.new(multi_consumer_config)
-      queue = Array.new
-      t = thread_it(kafka_input, queue)
-      t.run
-      wait(timeout_seconds).for { queue.length }.to eq(num_events)
-      expect(queue.length).to eq(num_events)
-      kafka_input.kafka_consumers.each_with_index do |consumer, i|
-        expect(consumer.metrics.keys.first.tags["client-id"]).to eq("spec-#{i}")
-      end
-    end
+    
   end
 
   describe "#kafka-topics-pattern" do
+    
     def thread_it(kafka_input, queue)
       Thread.new do
         begin
@@ -77,7 +65,7 @@ describe "inputs/kafka", :integration => true do
         end
       end
     end
-
+      
     it "should consume all messages from all 3 topics" do
       kafka_input = LogStash::Inputs::Kafka.new(pattern_config)
       queue = Array.new
@@ -85,7 +73,7 @@ describe "inputs/kafka", :integration => true do
       t.run
       wait(timeout_seconds).for { queue.length }.to eq(3*num_events)
       expect(queue.length).to eq(3*num_events)
-    end
+    end    
   end
 
   describe "#kafka-decorate" do
@@ -96,7 +84,7 @@ describe "inputs/kafka", :integration => true do
         end
       end
     end
-
+      
     it "should show the right topic and group name in decorated kafka section" do
       kafka_input = LogStash::Inputs::Kafka.new(decorate_config)
       queue = Queue.new

--- a/spec/unit/inputs/kafka_spec.rb
+++ b/spec/unit/inputs/kafka_spec.rb
@@ -16,7 +16,7 @@ class MockConsumer
       raise org.apache.kafka.common.errors.WakeupException.new
     else
       10.times.map do
-        org.apache.kafka.clients.consumer.ConsumerRecord.new("test", 0, 0, "key", "value")
+        org.apache.kafka.clients.consumer.ConsumerRecord.new("logstash", 0, 0, "key", "value")
       end
     end
   end
@@ -30,7 +30,7 @@ class MockConsumer
 end
 
 describe LogStash::Inputs::Kafka do
-  let(:config) { { 'topics' => ['test'], 'consumer_threads' => 4 } }
+  let(:config) { { 'topics' => ['logstash'], 'consumer_threads' => 4 } }
   subject { LogStash::Inputs::Kafka.new(config) }
 
   it "should register" do


### PR DESCRIPTION
* Adding feature for topic regex patterns and also decorate events with Kafka to provide data about the message consumed.

* Adding test cases for new features - kafka metadata decorator and regex topics and updated integration tests to be able to re run them multiple times.
* Fixed issue with travis build.
* Reduce fail wait time to 120 seconds to fail faster.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
