### PR TITLE
Added record timestamp to event decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.2.7
+  - fix: Added record timestamp in event decoration
+
 ## 6.2.6
   - fix: Client ID is no longer reused across multiple Kafka consumer instances
 

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -210,6 +210,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   #   `partition`: The partition this message is associated with
   #   `offset`: The offset from the partition this message is associated with
   #   `key`: A ByteBuffer containing the message key
+  #   `timestamp`: The timestamp of this message
   config :decorate_events, :validate => :boolean, :default => false
 
 
@@ -257,6 +258,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
                 event.set("[kafka][partition]", record.partition)
                 event.set("[kafka][offset]", record.offset)
                 event.set("[kafka][key]", record.key)
+                event.set("[kafka][timestamp]", record.timestamp)
               end
               logstash_queue << event
             end

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '6.3.0'
+  s.version         = '6.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '6.2.6'
+  s.version         = '6.2.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -98,6 +98,7 @@ describe "inputs/kafka", :integration => true do
     end
 
     it "should show the right topic and group name in decorated kafka section" do
+      start = LogStash::Timestamp.now.time.to_i
       kafka_input = LogStash::Inputs::Kafka.new(decorate_config)
       queue = Queue.new
       t = thread_it(kafka_input, queue)
@@ -107,6 +108,7 @@ describe "inputs/kafka", :integration => true do
       event = queue.shift
       expect(event.get("kafka")["topic"]).to eq("logstash_topic_plain")
       expect(event.get("kafka")["consumer_group"]).to eq(group_id_3)
+      expect(event.get("kafka")["timestamp"]).to be >= start
     end
   end
 end


### PR DESCRIPTION
This is a quick fix for #176 so event decorations contain the record timestamp.