### PR TITLE
Enable SLF4J to Log4J2 bridge for 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ This is a plugin for [Logstash](https://github.com/elastic/logstash).
 
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
 
+## Logging
+
+Kafka logs do not respect the Log4J2 root logger level and defaults to INFO, for other levels, you must explicitly set the log level in your Logstash deployment's `log4j2.properties` file, e.g.:
+```
+logger.kafka.name=org.apache.kafka
+logger.kafka.appenderRef.console.ref=console
+logger.kafka.level=debug
+```
+
 ## Documentation
 
 https://www.elastic.co/guide/en/logstash/current/plugins-inputs-kafka.html

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { 'logstash_plugin' => 'true', 'group' => 'input'}
 
   s.requirements << "jar 'org.apache.kafka:kafka-clients', '0.10.0.1'"
-  s.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.21'"
+  s.requirements << "jar 'org.apache.logging.log4j:log4j-slf4j-impl', '2.8.2'"
 
   s.add_development_dependency 'jar-dependencies', '~> 0.3.2'
 


### PR DESCRIPTION
This should enable Kafka logging in Log4J2 now, which was broken since the switch to Log4J2. Also README now clarifies how to set the Kafka log level in the Log4j2 properties.
