### PR TITLE
#118 Fix IT stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ lib/log4j/
 lib/net/
 lib/org/
 vendor/
+build/

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -8,29 +8,28 @@ else
    KAFKA_VERSION=0.10.2.1
 fi
 
+export _JAVA_OPTIONS="-Djava.net.preferIPv4Stack=true"
+
+rm -rf build
+mkdir build
+
 echo "Downloading Kafka version $KAFKA_VERSION"
-curl -s -o kafka.tgz "http://ftp.wayne.edu/apache/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
-mkdir kafka && tar xzf kafka.tgz -C kafka --strip-components 1
+curl -s -o build/kafka.tgz "http://ftp.wayne.edu/apache/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
+mkdir build/kafka && tar xzf build/kafka.tgz -C build/kafka --strip-components 1
 
 echo "Starting ZooKeeper"
-kafka/bin/zookeeper-server-start.sh -daemon kafka/config/zookeeper.properties
+build/kafka/bin/zookeeper-server-start.sh -daemon build/kafka/config/zookeeper.properties
 sleep 10
 echo "Starting Kafka broker"
-kafka/bin/kafka-server-start.sh -daemon kafka/config/server.properties
+build/kafka/bin/kafka-server-start.sh -daemon build/kafka/config/server.properties --override advertised.host.name=127.0.0.1 --override log.dirs="${PWD}/build/kafka-logs"
 sleep 10
 
 echo "Setting up test topics with test data"
-kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_plain --zookeeper localhost:2181
-sleep 10
-kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_snappy --zookeeper localhost:2181
-sleep 10
-kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_lz4 --zookeeper localhost:2181
-sleep 10
-wget https://s3.amazonaws.com/data.elasticsearch.org/apache_logs/apache_logs.txt
-cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_plain --broker-list localhost:9092
-sleep 10
-cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_snappy --broker-list localhost:9092 --compression-codec snappy
-sleep 10
-cat apache_logs.txt | kafka/bin/kafka-console-producer.sh --topic logstash_topic_lz4 --broker-list localhost:9092 --compression-codec lz4
-sleep 10
+build/kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_plain --zookeeper localhost:2181
+build/kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_snappy --zookeeper localhost:2181
+build/kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_topic_lz4 --zookeeper localhost:2181
+curl -s -o build/apache_logs.txt https://s3.amazonaws.com/data.elasticsearch.org/apache_logs/apache_logs.txt
+cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_topic_plain --broker-list localhost:9092
+cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_topic_snappy --broker-list localhost:9092 --compression-codec snappy
+cat build/apache_logs.txt | build/kafka/bin/kafka-console-producer.sh --topic logstash_topic_lz4 --broker-list localhost:9092 --compression-codec lz4
 echo "Setup complete, running specs"

--- a/kafka_test_teardown.sh
+++ b/kafka_test_teardown.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
-# Setup Kafka and create test topics
-
 set -ex
 
 echo "Stopping Kafka broker"
-kafka/bin/kafka-server-stop.sh
+build/kafka/bin/kafka-server-stop.sh
 echo "Stopping zookeeper"
-kafka/bin/zookeeper-server-stop.sh
+build/kafka/bin/zookeeper-server-stop.sh

--- a/spec/integration/inputs/kafka_spec.rb
+++ b/spec/integration/inputs/kafka_spec.rb
@@ -11,14 +11,15 @@ describe "inputs/kafka", :integration => true do
   let(:group_id_2) {rand(36**8).to_s(36)}
   let(:group_id_3) {rand(36**8).to_s(36)}
   let(:group_id_4) {rand(36**8).to_s(36)}
+  let(:group_id_5) {rand(36**8).to_s(36)}
   let(:plain_config) { { 'topics' => ['logstash_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
   let(:multi_consumer_config) { plain_config.merge({"group_id" => group_id_4, "client_id" => "spec", "consumer_threads" => 3}) }
   let(:snappy_config) { { 'topics' => ['logstash_topic_snappy'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
   let(:lz4_config) { { 'topics' => ['logstash_topic_lz4'], 'codec' => 'plain', 'group_id' => group_id_1, 'auto_offset_reset' => 'earliest'} }
   let(:pattern_config) { { 'topics_pattern' => 'logstash_topic_.*', 'group_id' => group_id_2, 'codec' => 'plain', 'auto_offset_reset' => 'earliest'} }  
   let(:decorate_config) { { 'topics' => ['logstash_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_3, 'auto_offset_reset' => 'earliest', 'decorate_events' => true} }
-  let(:manual_commit_config) { { 'topics' => ['logstash_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_4, 'auto_offset_reset' => 'earliest', 'enable_auto_commit' => 'false'} }
-  let(:timeout_seconds) { 120 }
+  let(:manual_commit_config) { { 'topics' => ['logstash_topic_plain'], 'codec' => 'plain', 'group_id' => group_id_5, 'auto_offset_reset' => 'earliest', 'enable_auto_commit' => 'false'} }
+  let(:timeout_seconds) { 30 }
   let(:num_events) { 103 }
 
   describe "#kafka-topics" do
@@ -32,40 +33,60 @@ describe "inputs/kafka", :integration => true do
 
     it "should consume all messages from plain 3-partition topic" do
       kafka_input = LogStash::Inputs::Kafka.new(plain_config)
-      queue = Array.new
+      queue = Queue.new
       t = thread_it(kafka_input, queue)
-      t.run
-      wait(timeout_seconds).for { queue.length }.to eq(num_events)
-      expect(queue.length).to eq(num_events)
+      begin
+        t.run
+        wait(timeout_seconds).for {queue.length}.to eq(num_events)
+        expect(queue.length).to eq(num_events)
+      ensure
+        t.kill
+        t.join(30_000)
+      end
     end
 
     it "should consume all messages from snappy 3-partition topic" do
       kafka_input = LogStash::Inputs::Kafka.new(snappy_config)
-      queue = Array.new
+      queue = Queue.new
       t = thread_it(kafka_input, queue)
-      t.run
-      wait(timeout_seconds).for { queue.length }.to eq(num_events)
-      expect(queue.length).to eq(num_events)
+      begin
+        t.run
+        wait(timeout_seconds).for {queue.length}.to eq(num_events)
+        expect(queue.length).to eq(num_events)
+      ensure
+        t.kill
+        t.join(30_000)
+      end
     end
 
     it "should consume all messages from lz4 3-partition topic" do
       kafka_input = LogStash::Inputs::Kafka.new(lz4_config)
-      queue = Array.new
+      queue = Queue.new
       t = thread_it(kafka_input, queue)
-      t.run
-      wait(timeout_seconds).for { queue.length }.to eq(num_events)
-      expect(queue.length).to eq(num_events)
+      begin
+        t.run
+        wait(timeout_seconds).for {queue.length}.to eq(num_events)
+        expect(queue.length).to eq(num_events)
+      ensure
+        t.kill
+        t.join(30_000)
+      end
     end
 
     it "should consumer all messages with multiple consumers" do
       kafka_input = LogStash::Inputs::Kafka.new(multi_consumer_config)
-      queue = Array.new
+      queue = Queue.new
       t = thread_it(kafka_input, queue)
-      t.run
-      wait(timeout_seconds).for { queue.length }.to eq(num_events)
-      expect(queue.length).to eq(num_events)
-      kafka_input.kafka_consumers.each_with_index do |consumer, i|
-        expect(consumer.metrics.keys.first.tags["client-id"]).to eq("spec-#{i}")
+      begin
+        t.run
+        wait(timeout_seconds).for {queue.length}.to eq(num_events)
+        expect(queue.length).to eq(num_events)
+        kafka_input.kafka_consumers.each_with_index do |consumer, i|
+          expect(consumer.metrics.keys.first.tags["client-id"]).to eq("spec-#{i}")
+        end
+      ensure
+        t.kill
+        t.join(30_000)
       end
     end
   end
@@ -81,11 +102,16 @@ describe "inputs/kafka", :integration => true do
 
     it "should consume all messages from all 3 topics" do
       kafka_input = LogStash::Inputs::Kafka.new(pattern_config)
-      queue = Array.new
+      queue = Queue.new
       t = thread_it(kafka_input, queue)
-      t.run
-      wait(timeout_seconds).for { queue.length }.to eq(3*num_events)
-      expect(queue.length).to eq(3*num_events)
+      begin
+        t.run
+        wait(timeout_seconds).for {queue.length}.to eq(3*num_events)
+        expect(queue.length).to eq(3*num_events)
+      ensure
+        t.kill
+        t.join(30_000)
+      end
     end
   end
 
@@ -102,12 +128,17 @@ describe "inputs/kafka", :integration => true do
       kafka_input = LogStash::Inputs::Kafka.new(decorate_config)
       queue = Queue.new
       t = thread_it(kafka_input, queue)
-      t.run
-      wait(timeout_seconds).for { queue.length }.to eq(num_events)
-      expect(queue.length).to eq(num_events)
-      event = queue.shift
-      expect(event.get("kafka")["topic"]).to eq("logstash_topic_plain")
-      expect(event.get("kafka")["consumer_group"]).to eq(group_id_3)
+      begin
+        t.run
+        wait(timeout_seconds).for {queue.length}.to eq(num_events)
+        expect(queue.length).to eq(num_events)
+        event = queue.shift
+        expect(event.get("kafka")["topic"]).to eq("logstash_topic_plain")
+        expect(event.get("kafka")["consumer_group"]).to eq(group_id_3)
+      ensure
+        t.kill
+        t.join(30_000)
+      end
     end
   end
 
@@ -122,11 +153,16 @@ describe "inputs/kafka", :integration => true do
 
     it "should manually commit offsets" do
       kafka_input = LogStash::Inputs::Kafka.new(manual_commit_config)
-      queue = Array.new
+      queue = Queue.new
       t = thread_it(kafka_input, queue)
-      t.run
-      wait(timeout_seconds).for { queue.length }.to eq(num_events)
-      expect(queue.length).to eq(num_events)
+      begin
+        t.run
+        wait(timeout_seconds).for {queue.length}.to eq(num_events)
+        expect(queue.length).to eq(num_events)
+      ensure
+        t.kill
+        t.join(30_000)
+      end
     end
   end
 end


### PR DESCRIPTION
For #118

Essentially just a rehash of https://github.com/elastic/logstash/pull/7092 plus:

* Use `Queue` instead of `Array` since adding to `Array` is not thread safe causing `adds` to be lost!
* Make sure Kafka consumer threads are in fact joined after a test run to make things less flaky from random background threads wasting resources
* Fixed group name collision in tests
* Removed pointless waits from bootstrap script
* Made bootstrap script not pollute index

Note: I did not go for the dockerized Kafka here yet, we should have a discussion about possible sharing some code with core here and not duplicate all over the place :)