### PR TITLE
missing bundle install before running any tests

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,5 +1,6 @@
 export KAFKA_VERSION=0.10.2.1
 ./kafka_test_setup.sh
+bundle install
 bundle exec rake vendor
 bundle exec rspec && bundle exec rspec --tag integration
 ./kafka_test_teardown.sh


### PR DESCRIPTION
The run.sh was missing the bundle install command before running any
tests, this was making the build fails