### PR TITLE
Add charset conversion feature.

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -1,5 +1,6 @@
 require 'logstash/namespace'
 require 'logstash/inputs/base'
+require "logstash/util/charset"
 require 'stud/interval'
 require 'java'
 require 'logstash-input-kafka_jars.rb'
@@ -214,9 +215,18 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config :decorate_events, :validate => :boolean, :default => false
 
 
+  # Option for charset conversion, default is UTF-8, especially useful when after one codec applied.
+  config :charset, :validate => ::Encoding.name_list, :default => "UTF-8"
+
+  # Option for what fields need to be converted to the charset specified by option charset. Default is an empty array.
+  # Once a unexist field set, an error log will be writen into the log.
+  config :charset_field, :validate => :array, :default => []
+
   public
   def register
     @runner_threads = []
+    @converter = LogStash::Util::Charset.new(@charset)
+    @converter.logger = @logger
   end # def register
 
   public
@@ -253,6 +263,15 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
           for record in records do
             codec_instance.decode(record.value.to_s) do |event|
               decorate(event)
+              unless @charset_field.empty?
+                @charset_field.each do |e|
+                  unless event.get(e).nil?
+                    event.set(e,@converter.convert(event.get(e)))
+                  else
+                    @logger.error("No such field:[" + e + "]. Skip it for charset conversion.")
+                  end
+                end
+              end
               if @decorate_events
                 event.set("[@metadata][kafka][topic]", record.topic)
                 event.set("[@metadata][kafka][consumer_group]", @group_id)


### PR DESCRIPTION
Our senario is to collect to some logs encoded by GBK (a Chinese encoding) rather than UTF-8.

We use flume taildirectorysource plugin to do the collection. After avro serialization, the event was sent to kafka. And then we use logstash-kafka-input to fetch and send it to elasticsearch. The data flow is:

> Logs(GBK) -> flume (avro serialization)->kafka-> logstash-kafka-input (avro codec to do the avro  deserialization) -> elasticsearch

the input config is:

```
input {
        kafka {
                bootstrap_servers => "DPFTMP06:9092"
                max_partition_fetch_bytes => "3145728"
                topics =>["emu-topic"]
                group_id => "logstashc"
                auto_offset_reset => "earliest"
                consumer_threads => 8
                key_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
                value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
                charset => "GBK"
                charset_field => ["message"]
                codec => avro {
                        schema_uri => "/logger/logstash/configM/test.avsc"
                }
        }
}
```


If the logs were UTF-8, it won't cause any trouble. Unfortunately, the logs are GBK. So the kibana will show garbled message when it contains Chinese.

With this pr, we can convert it to the correct to encoding after codec in this input plugin.

Please check, thank you!
