### PR TITLE
Replace compatibility table with a link to the official Kafka compati…

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -22,7 +22,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 This input will read events from a Kafka topic.
 
-This plugin uses Kafka Client 0.11.0. For broker compatibility, see the https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka Compatibility Matrix].
+This plugin uses Kafka Client 0.11.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference].
 
 If you are using a newer version of this plugin, you will want to read the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin version documentation]. 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -20,26 +20,11 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-This input will read events from a Kafka topic. It uses the 0.10 version of
-the consumer API provided by Kafka to read messages from the broker.
+This input will read events from a Kafka topic.
 
-Here's a compatibility matrix that shows the Kafka client versions that are compatible with each combination
-of Logstash and the Kafka input plugin: 
+This plugin uses Kafka Client 0.11.0. For broker compatibility, see the https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka Compatibility Matrix].
 
-[options="header"]
-|==========================================================
-|Kafka Client Version |Logstash Version |Plugin Version |Why?
-|0.8       |2.0.0 - 2.x.x   |<3.0.0 |Legacy, 0.8 is still popular 
-|0.9       |2.0.0 - 2.3.x   | 3.x.x |Works with the old Ruby Event API (`event['product']['price'] = 10`)  
-|0.9       |2.4.x - 5.x.x   | 4.x.x |Works with the new getter/setter APIs (`event.set('[product][price]', 10)`)
-|0.10.0.x  |2.4.x - 5.x.x   | 5.x.x |Not compatible with the <= 0.9 broker
-|0.10.1.x  |2.4.x - 5.x.x   | 6.x.x |
-|0.11.0.0  |2.4.x - 5.x.x   | 6.x.x |Not compatible with the <= 0.9 broker
-|==========================================================
-
-NOTE: We recommended that you use matching Kafka client and broker versions. During upgrades, you should
-upgrade brokers before clients because brokers target backwards compatibility. For example, the 0.9 broker
-is compatible with both the 0.8 consumer and 0.9 consumer APIs, but not the other way around.
+If you are using a newer version of this plugin, you will want to read the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin version documentation]. 
 
 This input supports connecting to Kafka over:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,7 +24,7 @@ This input will read events from a Kafka topic.
 
 This plugin uses Kafka Client 0.11.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference].
 
-If you are using a newer version of this plugin, you will want to read the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin version documentation]. 
+If you're using a plugin version that was released after {version}, see the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin documentation] for updated information about Kafka compatibility.
 
 This input supports connecting to Kafka over:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -22,7 +22,7 @@ include::{include_path}/plugin_header.asciidoc[]
 
 This input will read events from a Kafka topic.
 
-This plugin uses Kafka Client 0.11.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference].
+This plugin uses Kafka Client 1.0.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference].
 
 If you're using a plugin version that was released after {version}, see the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin documentation] for updated information about Kafka compatibility.
 


### PR DESCRIPTION
Implementation of https://github.com/logstash-plugins/logstash-output-kafka/issues/156

This is a draft implementation that has a few major improvements over the current matrix:

* It refers users to the official Kafka compatibility documentation about client-broker compatibility
* It eliminates the compatibility matrix content.
* It pushes the burden of "What kafka broker works with Logstash?" on the Kafka project which is already documenting these details

I am hoping that users find this easier to understand than the difficult table we were maintaining before. Further, new Kafka releases will not require updating the now-deleted compatibility table, which is very exciting to me.