### PR TITLE
Upgrade to Kafka 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.0.4
+  - Upgrade Kafka client to version 1.0.0
+
 ## 8.0.3
   - Update gemspec summary
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,4 +1,4 @@
-export KAFKA_VERSION=0.10.2.1
+export KAFKA_VERSION=1.0.0
 ./kafka_test_setup.sh
 bundle install
 bundle exec rake vendor

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '8.0.3'
+  s.version         = '8.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Kafka topic"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'input'}
 
-  s.requirements << "jar 'org.apache.kafka:kafka-clients', '0.11.0.0'"
+  s.requirements << "jar 'org.apache.kafka:kafka-clients', '1.0.0'"
   s.requirements << "jar 'org.apache.logging.log4j:log4j-slf4j-impl', '2.8.2'"
 
   s.add_development_dependency 'jar-dependencies', '~> 0.3.2'


### PR DESCRIPTION
Upgrading to `1.0.0`. Only did a minor version bump because of full BwC with `0.11.0.0` here.

* Needed to fix the ITs to download `1.0.0` too, the old version wasn't available for download anymore from the Url that the `sh` script was using.
* Test failure is the same in `master` and looks like some `rake` version issue