### PR TITLE
Highlight a request for specific details when a user wants a not-yet-supported feature.

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,7 +24,8 @@ This input will read events from a Kafka topic.
 
 This plugin uses Kafka Client 1.0.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference].
 
-If you're using a plugin version that was released after {version}, see the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin documentation] for updated information about Kafka compatibility.
+If you're using a plugin version that was released after {version}, see the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin documentation] for updated information about Kafka compatibility. If you require features not yet available in this plugin (including client version upgrades), please file an issue with details about what you need..
+
 
 This input supports connecting to Kafka over:
 


### PR DESCRIPTION
This is per discussion with @acchen97 and myself to improve the
messaging around the Kafka plugins.