### PR TITLE
Replace version matrix with link to Kafka compatibility reference.

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -20,26 +20,12 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-This input will read events from a Kafka topic. It uses the 0.10 version of
-the consumer API provided by Kafka to read messages from the broker.
+This input will read events from a Kafka topic.
 
-Here's a compatibility matrix that shows the Kafka client versions that are compatible with each combination
-of Logstash and the Kafka input plugin: 
+This plugin uses Kafka Client 0.11.0.0. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference].
 
-[options="header"]
-|==========================================================
-|Kafka Client Version |Logstash Version |Plugin Version |Why?
-|0.8       |2.0.0 - 2.x.x   |<3.0.0 |Legacy, 0.8 is still popular 
-|0.9       |2.0.0 - 2.3.x   | 3.x.x |Works with the old Ruby Event API (`event['product']['price'] = 10`)  
-|0.9       |2.4.x - 5.x.x   | 4.x.x |Works with the new getter/setter APIs (`event.set('[product][price]', 10)`)
-|0.10.0.x  |2.4.x - 5.x.x   | 5.x.x |Not compatible with the <= 0.9 broker
-|0.10.1.x  |2.4.x - 5.x.x   | 6.x.x |
-|0.11.0.0  |2.4.x - 5.x.x   | 6.x.x |Not compatible with the <= 0.9 broker
-|==========================================================
+If you're using a plugin version that was released after {version}, see the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin documentation] for updated information about Kafka compatibility. If you require features not yet available in this plugin (including client version upgrades), please file an issue with details about what you need..
 
-NOTE: We recommended that you use matching Kafka client and broker versions. During upgrades, you should
-upgrade brokers before clients because brokers target backwards compatibility. For example, the 0.9 broker
-is compatible with both the 0.8 consumer and 0.9 consumer APIs, but not the other way around.
 
 This input supports connecting to Kafka over:
 


### PR DESCRIPTION
Kafka clients version was determined by checking the .gemspec

Parent issue: https://github.com/logstash-plugins/logstash-output-kafka/issues/156
