### PR TITLE
When re-raising an exception, use `Kernel#raise`

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -327,7 +327,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       logger.error("Unable to create Kafka consumer from given configuration",
                    :kafka_error_message => e,
                    :cause => e.respond_to?(:getCause) ? e.getCause() : nil)
-      throw e
+      raise e
     end
   end
 


### PR DESCRIPTION
While Ruby has `throw`/`catch` that is rarely used for flow-control, it's not
the exception-handling analog to Java's throw/catch; the analog we're
looking for is `raise`/`rescue`.

Using [`Kernel#throw`] without an outer matching [`Kernel#catch`] results
in an `UncaughtThrowError`.

[`Kernel#throw`]: https://ruby-doc.org/core-2.2.3/Kernel.html#method-i-throw
[`Kernel#catch`]: https://ruby-doc.org/core-2.2.3/Kernel.html#method-i-catch
