### PR TITLE
Manually install jar-dependencies to fix build on 5.6 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 ---
 sudo: false
 language: ruby
-cache: bundler
+before_install:
+- gem install jar-dependencies
 matrix:
   include:
   - rvm: jruby-9.1.13.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,12 @@
 source 'https://rubygems.org'
 
+# This will ensure that the jar-dependencies gem is installed by bundler
+gem "jar-dependencies", "~> 0.3.2"
+
 gemspec
 
 logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+
 use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
 
 if Dir.exist?(logstash_path) && use_logstash_source

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'bundler'
+Bundler.require(:development)
 require "logstash/devutils/rake"
 
 task :default do

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,3 +1,4 @@
+
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
   s.version         = '8.0.4'
@@ -21,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << "jar 'org.apache.kafka:kafka-clients', '1.0.0'"
   s.requirements << "jar 'org.apache.logging.log4j:log4j-slf4j-impl', '2.8.2'"
 
-  s.add_development_dependency 'jar-dependencies', '~> 0.3.2'
+  s.add_runtime_dependency 'jar-dependencies', '~> 0.3.2'
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"


### PR DESCRIPTION
The current build is failing on this and many other projects that
 use jar-dependencies, because jar-dependencies is added as a
 development dependency, which does not get installed on the Travis
 box during a `bundle install`. This commit attempts to fix this
 by adding a manual step to install the gem

