### PR TITLE
Commit offset only if records were consumed

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -250,6 +250,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
         codec_instance = @codec.clone
         while !stop?
           records = consumer.poll(poll_timeout_ms)
+          next unless records.count > 0
           for record in records do
             codec_instance.decode(record.value.to_s) do |event|
               decorate(event)


### PR DESCRIPTION
Currently offsets are committed after each poll, even if no records were
consumed.