### PR TITLE
stop gracefully when not yet fully started

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -228,7 +228,8 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
 
   public
   def stop
-    @runner_consumers.each { |c| c.wakeup }
+    # if we have consumers, wake them up to unblock our runner threads
+    @runner_consumers && @runner_consumers.each(&:wakeup)
   end
 
   public


### PR DESCRIPTION
When the Kafka Input is sent `stop` (as in a configuration reload or shutdown),
and it has not yet been fully started, it is possible that `@runner_consumers`
will not be set.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
