### PR TITLE
[DOCS] Fix list formatting and add default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.2
+ - Docs: Correct list formatting for `decorate_events`
+ - Docs: Add kafka default to `partition_assignment_strategy`
+
 ## 8.1.1
  - Fix race-condition where shutting down a Kafka Input before it has finished starting could cause Logstash to crash
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -67,7 +67,10 @@ inserted into your original event, you'll have to use the `mutate` filter to man
 [id="plugins-{type}s-{plugin}-options"]
 ==== Kafka Input Configuration Options
 
-This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+This plugin supports these configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+NOTE: Some of these options map to a Kafka option. See the
+https://kafka.apache.org/documentation for more details.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -200,11 +203,12 @@ balance — more threads than partitions means that some threads will be idl
 
 Option to add Kafka metadata like topic, message size to the event.
 This will add a field named `kafka` to the logstash event containing the following attributes:
-  `topic`: The topic this message is associated with
-  `consumer_group`: The consumer group used to read in this event
-  `partition`: The partition this message is associated with
-  `offset`: The offset from the partition this message is associated with
-  `key`: A ByteBuffer containing the message key
+
+* `topic`: The topic this message is associated with
+* `consumer_group`: The consumer group used to read in this event
+* `partition`: The partition this message is associated with
+* `offset`: The offset from the partition this message is associated with
+* `key`: A ByteBuffer containing the message key
 
 [id="plugins-{type}s-{plugin}-enable_auto_commit"]
 ===== `enable_auto_commit` 
@@ -363,8 +367,10 @@ we haven't seen any partition leadership changes to proactively discover any new
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-The class name of the partition assignment strategy that the client will use to distribute
-partition ownership amongst consumer instances
+The class name of the partition assignment strategy that the client uses to
+distribute partition ownership amongst consumer instances. Maps to
+the Kafka `partition.assignment.strategy` setting, which defaults to
+`org.apache.kafka.clients.consumer.RangeAssignor`.
 
 [id="plugins-{type}s-{plugin}-poll_timeout_ms"]
 ===== `poll_timeout_ms` 

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-kafka'
-  s.version         = '8.1.1'
+  s.version         = '8.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Kafka topic"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
**Documentation changes**
 - Correct list formatting for `decorate_events`
 - Add kafka default to `partition_assignment_strategy` and another reference to Kafka documentation. (I didn't add a deep link to content, but rather a general note that some of our settings map to a kafka setting.)

The formatting change is related to general plugin doc cleanup and quality. The Kafka changes are in response to questions from the field. 
