### PR TITLE
[DOCS] Add note about decorate_events

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -61,6 +61,8 @@ The following metadata from Kafka broker are added under the `[@metadata]` field
 * `[@metadata][kafka][key]`: Record key, if any.
 * `[@metadata][kafka][timestamp]`: Timestamp in the Record. Depending on your broker configuration, this can be either when the record was created (default) or when it was received by the broker. See more about property log.message.timestamp.type at https://kafka.apache.org/10/documentation.html#brokerconfigs
 
+Metadata is only added to the event if the `decorate_events` option is set to true (it defaults to false).
+
 Please note that `@metadata` fields are not part of any of your events at output time. If you need these information to be 
 inserted into your original event, you'll have to use the `mutate` filter to manually copy the required fields into your `event`.
 


### PR DESCRIPTION
See https://discuss.elastic.co/t/kafka-input-plugin-does-not-set-metadata-fields/125256 . We just hit this gotcha and scratched our heads. This should clearly be stated in the docs.